### PR TITLE
Handle partial content (206) responses.

### DIFF
--- a/httpc.c
+++ b/httpc.c
@@ -874,7 +874,10 @@ static int httpc_parse_response_header_start_line(httpc_t *h, char *line, const 
 	if (h->response < 200 || h->response > 399)
 		return error(h, "invalid response number: %u", h->response);
 	if (h->response >= 200 && h->response <= 299) {
-		if (ok[0] == '\0' || ok[1] == '\0' || 0 != httpc_case_insensitive_compare(ok, "OK", 2))
+		int is_empty   = ok[0] == '\0' || ok[1] == '\0';
+		int is_ok      = is_empty ? 0 : httpc_case_insensitive_compare(ok, "OK", 2) == 0;
+		int is_partial = is_ok    ? 0 : httpc_case_insensitive_compare(ok, "Partial Content", 15) == 0;
+		if (is_empty || (!is_ok && !is_partial))
 			return error(h, "unexpected HTTP response: %s", ok);
 	}
 	return HTTPC_OK;


### PR DESCRIPTION
By passing `Range: <type>=<from>-<to>` it's possible to request parts of a resource if the server supports it.

For example:
```
$ ./httpc -H "Range: bytes=0-9" example.com
<!doctype 
```

Previously `httpc` couldn't understand the response and retried:
```
$ ./httpc -v -H "Range: bytes=0-9" example.com
info:1091 Program: Embeddable HTTP 1.0/1.1 client
info:1092 Version: 3.1.5
info:1093 Repo:    https://github.com/howerj/httpc
info:1094 Author:  Richard James Howe
info:1095 Email:   howe.r.j.89@gmail.com
info:1096 Options: stk=128 tst=1 grw=1 log=1 cons=3 redirs=3 hmax=8192 sz=584
info:1100 License: The Unlicense (public domain)
info:521 domain:    example.com
info:522 port:      80
info:523 SSL:       false
info:526 path       /
debug:1309 state -- initial   -> open     
debug:1309 state -- open      -> send-head
debug:634 custom header 'Range: bytes=0-9' added
info:642 GET  request complete
debug:1309 state -- send-head -> send-body
info:1032 no callback - nothing to do
debug:1309 state -- send-body -> recv-head
info:903 HEADER: HTTP/1.1 206 Partial Content/28
error:878 unexpected HTTP response: Partial Content
```