### PR TITLE
Input needed: Clear callbacks and lengths on requests

### DIFF
--- a/httpc.c
+++ b/httpc.c
@@ -1394,20 +1394,17 @@ static int httpc_op_heap(httpc_options_t *a, const char *url, int op, httpc_call
 		h = a->allocator(a->arena, NULL, 0, sizeof *h);
 		if (!h)
 			return HTTPC_ERROR;
-		memset(h, 0, sizeof *h);
-		a->state     = h;
 	}
 
+	void *socket = h->socket;
+	memset(h, 0, sizeof *h);
+	a->state     = h;
 	h->os        = a;
 	h->rcv       = rcv;
 	h->snd       = snd;
 	h->rcv_param = rcv_param;
 	h->snd_param = snd_param;
-	h->position = 0;
-	h->length = 0;
-	h->max = 0;
-	h->length_set = 0;
-	h->state = SM_INIT;
+	h->socket    = socket;
 	const int r = httpc_state_machine(h, url, op);
 	if (r != HTTPC_YIELD && r != HTTPC_REUSE)
 		a->state = NULL; /* make sure this is not reused */

--- a/httpc.c
+++ b/httpc.c
@@ -1395,12 +1395,18 @@ static int httpc_op_heap(httpc_options_t *a, const char *url, int op, httpc_call
 			return HTTPC_ERROR;
 		memset(h, 0, sizeof *h);
 		a->state     = h;
-		h->os        = a;
-		h->rcv       = rcv;
-		h->snd       = snd;
-		h->rcv_param = rcv_param;
-		h->snd_param = snd_param;
 	}
+
+	h->os        = a;
+	h->rcv       = rcv;
+	h->snd       = snd;
+	h->rcv_param = rcv_param;
+	h->snd_param = snd_param;
+	h->position = 0;
+	h->length = 0;
+	h->max = 0;
+	h->length_set = 0;
+	h->state = SM_INIT;
 	const int r = httpc_state_machine(h, url, op);
 	if (r != HTTPC_YIELD && r != HTTPC_REUSE)
 		a->state = NULL; /* make sure this is not reused */

--- a/httpc.c
+++ b/httpc.c
@@ -783,6 +783,7 @@ static int httpc_parse_response_field(httpc_t *h, char *line, size_t length) {
 			if (httpc_scan_number(&line[fld->length], &h->length, 10) < 0)
 				return error(h, "invalid content length: %s", line);
 			h->length_set = 1;
+			h->os->content_length = h->length;
 			return info(h, "Content Length: %lu", (unsigned long)h->length);
 		case FLD_REDIRECT:
 			if (h->os->response >= 300 && h->os->response < 399) {

--- a/httpc.h
+++ b/httpc.h
@@ -55,6 +55,7 @@ struct httpc_options { /* Note that get/put/etcetera functions can *write* to th
 
 	void *context;    /* For your use, feel free to fill with good thoughts and positive affirmations */
 	int response;     /* HTTP response code; set after the header is retrieved. */
+	int content_length;
 };
 
 


### PR DESCRIPTION
State: Do not merge. Need input before finalizing or discarding PR

I've been looking into fixing the issues with #7 and added state clearing when re-using non-yielding connections. This fixes the issue with requests not working when doing a `GET` after a `HEAD` (due to empty callbacks on the reused `httpc_t` instance). However, I have a feeling I'm missing something.

**Q**: Is this the correct approach?
**Q**: Should additional fields be cleared?
**Q**: Will this play nicely with yields?

Ignore the `content_length` field. I need it for my local tests but it will be cleaned up and removed.