### PR TITLE
added response 204 as valid response

### DIFF
--- a/httpc.c
+++ b/httpc.c
@@ -907,6 +907,7 @@ static int httpc_parse_response_header_start_line(httpc_t *h, char *line, const 
 			{ 200, "OK", }, /* Default response, always allowed */
 			{ 201, "Created", },
 			{ 202, "Accepted", },
+			{ 204, "No Content", },
 			{ 206, "Partial Content", },
 			{ 218, "This is fine", },
 		};


### PR DESCRIPTION
Hi

when writing data to InfluxDB, InfluxDB responds with `204 No Content`, this library didn't recognise this as valid response and returned with error.
I've added this response into list of responses and it seems to work now