### PR TITLE
enable to recieve body if recieve callback provided

### DIFF
--- a/httpc.c
+++ b/httpc.c
@@ -1258,7 +1258,7 @@ next_state:
 	}
 	case SM_RCVB:
 		next = SM_DONE;
-		if (op == HTTPC_GET) {
+		if (h->rcv) {
 			const httpc_length_t pos = h->position;
 			h->progress = 0;
 			const int r = httpc_parse_response_body(h);
@@ -1435,6 +1435,12 @@ int httpc_post(httpc_options_t *a, const char *url, httpc_callback fn, void *par
 	assert(a);
 	assert(url);
 	return httpc_operation(a, url, HTTPC_POST, NULL, NULL, fn, param);
+}
+
+int httpc_post_with_response_body(httpc_options_t *a, const char *url, httpc_callback rxfn, void *rxparam, httpc_callback txfn, void *txparam) {
+	assert(a);
+	assert(url);
+	return httpc_operation(a, url, HTTPC_POST, rxfn, rxparam, txfn, txparam);
 }
 
 int httpc_head(httpc_options_t *a, const char *url) {

--- a/httpc.h
+++ b/httpc.h
@@ -72,6 +72,7 @@ typedef struct httpc httpc_t;
 HTTPC_API int httpc_get(httpc_options_t *a, const char *url, httpc_callback fn, void *param);
 HTTPC_API int httpc_put(httpc_options_t *a, const char *url, httpc_callback fn, void *param); /* fn should return size, 0 on stop, -1 on failure */
 HTTPC_API int httpc_post(httpc_options_t *a, const char *url, httpc_callback fn, void *param); /* fn should return size, 0 on stop, -1 on failure */
+HTTPC_API int httpc_post_with_response_body(httpc_options_t *a, const char *url, httpc_callback rxfn, void *rxparam, httpc_callback txfn, void *txparam); /* fn should return size, 0 on stop, -1 on failure */
 HTTPC_API int httpc_get_buffer(httpc_options_t *a, const char *url, char *buffer, size_t *length); /* store GET to buffer */
 HTTPC_API int httpc_put_buffer(httpc_options_t *a, const char *url, char *buffer, size_t length); /* PUT from buffer */
 HTTPC_API int httpc_post_buffer(httpc_options_t *a, const char *url, char *buffer, size_t length); /* POST from buffer */


### PR DESCRIPTION
Hi
this library would parse recieve body only in GET operation.
I need to be able to parse recieved body even in POST, so i created `httpc_post_with_response_body` function that provides both send and recieve callbacks, and slightly modified state machine, so it parses recieve body if recieve callback is provided.